### PR TITLE
Made change to start script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ src/postgresSettings.py
 node_modules
 bundle.js
 npm-debug.log
+logs/
 */Icon\r
 */.DS_Store

--- a/start.sh
+++ b/start.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
 
+trap 'kill %1' SIGINT
+
 # This script starts up the development session on localhost:8080
-pushd $(dirname $0) >> /dev/null
+pushd $(dirname $0) &> /dev/null
 
-pushd src >> /dev/null
-python main.py >> /dev/null &
+mkdir -p logs
+logdir=$(pwd)/logs
 
-pushd static/js >> /dev/null
-npm start --silent >> /dev/null &
+pushd src &> /dev/null
+python main.py 2>&1 | tee ${logdir}/python.log | sed -e 's/^/[Python] /' &
 
-popd >> /dev/null
-popd >> /dev/null
-popd >> /dev/null
+pushd static/js &> /dev/null
+npm start 2>&1 | tee $logdir/node.log | sed -e 's/^/[Node]   /'
+
+popd &> /dev/null
+popd &> /dev/null
+popd &> /dev/null
 echo "Session successfully started"
+jobs
 exit 0


### PR DESCRIPTION
The start script will now background only 1 of the processes. It also adds a trap on the `SIGINT` signal so that we can kill the first job as well. Everything is also piped through `tee` and `sed` into log files (which are ignored in git)